### PR TITLE
feat: add MongoDB database as a part of the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ scaffoldr --no-banner generate my-project
 When you generate a FastAPI project, you get:
 
 - **Complete FastAPI Application**: Pre-configured with proper structure
-- **Database Integration**: SQLAlchemy with Alembic migrations
+- **Database Integration**: SQLAlchemy with Alembic migrations or MongoDB with Beanie ODM
 - **File Storage**: Built-in file upload/download endpoints
 - **API Documentation**: Auto-generated OpenAPI/Swagger docs
 - **Development Tools**: Pre-configured with ruff, mypy, pytest
@@ -117,7 +117,9 @@ my-project/
 │       ├── core/               # Core components (config, utils, etc.)
 │       ├── features/           # Feature modules (business logic)
 │       ├── services/           # External service integrations
-│       └── database/           # Data access layer
+{% if database %}
+│       └── database/           # Data access layer (SQLAlchemy or MongoDB)
+{% endif %}
 ├── tests/                      # Comprehensive test suite
 ├── scripts/                    # Development scripts
 ├── .github/                    # GitHub workflows and templates

--- a/src/scaffoldr/cli/generate.py
+++ b/src/scaffoldr/cli/generate.py
@@ -38,6 +38,10 @@ class GenerateCommand:
 		if use_cloud:
 			cloud_type = Helper.cloud_type()
 
+		database_type = None
+		if use_database:
+			database_type = Helper.database_type()
+
 		project_name = project_name.replace(" ", "-").lower()
 		# Check if directory already exists
 		if destination == ".":
@@ -71,6 +75,7 @@ class GenerateCommand:
 			"use_docker": docker,
 			"cloud_type": cloud_type,
 			"database": use_database,
+			"database_type": database_type,
 			"framework": framework,
 		}
 

--- a/src/scaffoldr/core/constants/__init__.py
+++ b/src/scaffoldr/core/constants/__init__.py
@@ -1,8 +1,9 @@
 from .art import ascii_art
-from .const import CloudTypes, Frameworks, console
+from .const import CloudTypes, DatabaseTypes, Frameworks, console
 
 __all__ = [
 	"CloudTypes",
+	"DatabaseTypes",
 	"Frameworks",
 	"ascii_art",
 	"console",

--- a/src/scaffoldr/core/constants/const.py
+++ b/src/scaffoldr/core/constants/const.py
@@ -18,3 +18,8 @@ class CloudTypes(str, Enum):
 	GCP = "gcp"
 	AZURE = "azure"
 	NONE = "none"
+
+
+class DatabaseTypes(str, Enum):
+	SQLALCHEMY = "sqlalchemy"
+	MONGODB = "mongodb"

--- a/src/scaffoldr/core/utils/helper.py
+++ b/src/scaffoldr/core/utils/helper.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, cast
 import typer
 from copier import subprocess
 
-from scaffoldr.core.constants.const import CloudTypes
+from scaffoldr.core.constants.const import CloudTypes, DatabaseTypes, console
 
 if TYPE_CHECKING:
 	from collections.abc import Iterable
@@ -40,6 +40,20 @@ class Helper:
 		cloud_type: str = cast("str", typer.prompt(f"Cloud type: {' | '.join(cloud_types)}"))
 		if cloud_type in cloud_types:
 			return cloud_type
-		raise ValueError(
-			f"Invalid cloud type: {cloud_type}. Must be one of: {' | '.join(cloud_types)}",
+		console.print(f"[red]Error:[/red] Invalid cloud type: {cloud_type}")
+		raise typer.Exit(1)
+
+	@staticmethod
+	def database_type() -> str:
+		"""
+		Prompt for database type selection.
+		"""
+		database_types = list(DatabaseTypes)
+		database_type: str = cast(
+			"str",
+			typer.prompt(f"Database type: {' | '.join(database_types)}"),
 		)
+		if database_type in database_types:
+			return database_type
+		console.print(f"[red]Error:[/red] Invalid database type: {database_type}")
+		raise typer.Exit(1)

--- a/templates/fastapi_template/{{ project_name }}/.env.jinja
+++ b/templates/fastapi_template/{{ project_name }}/.env.jinja
@@ -13,8 +13,15 @@
 {{ project_slug|upper }}_LOG_GRANIAN_ERROR_LEVEL=40
 
 {% if database %}
+{% if database_ype == 'postgresql' %}
+{{ project_slug|upper }}_DB_URL=postgresql+asyncpg://user:password@localhost:5432/{{ project_slug }}
+{{ project_slug|upper }}_DB_ECHO=false
+{% elif database_type == 'sqlite' %}
 {{ project_slug|upper }}_DB_URL=sqlite+aiosqlite:///./{{ project_name|upper }}.db
 {{ project_slug|upper }}_DB_ECHO=false
+{% elif database_type == 'mongodb' %}
+{{ project_slug|upper }}_DB_URL=mongodb://localhost:27017
+{% endif %}
 {% endif %}
 
 {% if cloud_type %}

--- a/templates/fastapi_template/{{ project_name }}/README.md.jinja
+++ b/templates/fastapi_template/{{ project_name }}/README.md.jinja
@@ -6,8 +6,15 @@
 
 - **FastAPI**: Modern, fast web framework for building APIs
 - **Pydantic**: Data validation and serialization
+{% if database %}
+{% if database_type == 'sqlalchemy' %}
 - **SQLAlchemy**: SQL toolkit and ORM
 - **Alembic**: Database migration tool
+{% elif database_type == 'mongodb' %}
+- **Beanie**: MongoDB ODM for Python
+- **Motor**: Asynchronous MongoDB driver
+{% endif %}
+{% endif %}
 - **Uvicorn**: ASGI web server
 - **Granian**: High-performance web server
   {% if cloud_type == 'aws' %}

--- a/templates/fastapi_template/{{ project_name }}/pyproject.toml.jinja
+++ b/templates/fastapi_template/{{ project_name }}/pyproject.toml.jinja
@@ -39,8 +39,14 @@ dependencies = [
 	"azure-identity>=1.25.0",
 	{% endif %}
 	{% if database %}
+	{% if database_type == 'sqlalchemy' %}
 	"aiosqlite>=0.21.0",
 	"sqlalchemy[asyncio]>=2.0.0",
+	{% elif database_type == 'mongodb' %}
+	"beanie>=2.0.0",
+	"motor>=3.7.1",
+	"pymongo>=4.15.1",
+	{% endif %}
 	{% endif %}
 	"fastapi>=0.117.1",
 	"granian[reload]>=2.5.4",

--- a/templates/fastapi_template/{{ project_name }}/src/{{ project_slug }}/api/lifespan.py.jinja
+++ b/templates/fastapi_template/{{ project_name }}/src/{{ project_slug }}/api/lifespan.py.jinja
@@ -4,7 +4,11 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 {% if database %}
+{% if database_type == 'sqlalchemy' %}
 from {{ project_slug }}.connection import Base, database
+{% elif database_type == 'mongodb' %}
+from {{ project_slug }}.connection import mongodb
+{% endif %}
 {% endif %}
 
 {% if framework == 'fastapi' %}
@@ -12,10 +16,19 @@ from {{ project_slug }}.connection import Base, database
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
 {% if database %}
+{% if database_type == 'sqlalchemy' %}
 	async with database.engine.begin() as conn:
 		# run_sync executes the given function in a sync context using the connection
 		await conn.run_sync(Base.metadata.create_all)
-	{% endif %}
+{% elif database_type == 'mongodb' %}
+	await mongodb.connect()
+{% endif %}
+{% endif %}
 	yield
+{% if database %}
+{% if database_type == 'mongodb' %}
+	await mongodb.close()
+{% endif %}
+{% endif %}
 
 {% endif %}

--- a/templates/fastapi_template/{{ project_name }}/src/{{ project_slug }}/connection/__init__.py.jinja
+++ b/templates/fastapi_template/{{ project_name }}/src/{{ project_slug }}/connection/__init__.py.jinja
@@ -1,4 +1,7 @@
-{% if database %}
+{% if database_type == 'sqlalchemy' %}
 from .database import database, inject_session, Base
 __all__ = ["Base", "database", "inject_session"]
+{% elif database_type == 'mongodb' %}
+from .database import mongodb
+__all__ = ["mongodb"]
 {% endif %}

--- a/templates/fastapi_template/{{ project_name }}/src/{{ project_slug }}/connection/{% if database %}database.py{% endif %}.jinja
+++ b/templates/fastapi_template/{{ project_name }}/src/{{ project_slug }}/connection/{% if database %}database.py{% endif %}.jinja
@@ -1,3 +1,4 @@
+{% if database_type == 'sqlalchemy' %}
 from collections.abc import AsyncGenerator, Callable
 from functools import wraps
 from typing import Any, cast
@@ -74,3 +75,44 @@ def inject_session(func: Callable[..., Any]) -> Callable[..., Any]:
 		return None  # This should never be reached, but for type safety
 
 	return cast("Callable[..., Any]", wrapper)
+{% elif database_type == 'mongodb' %}
+from beanie import init_beanie
+from motor.motor_asyncio import AsyncIOMotorClient
+from typing import Optional
+
+from {{ project_slug }}.core.config import settings
+
+
+class MongoDB:
+	"""MongoDB connection manager using Beanie ODM."""
+
+	def __init__(self) -> None:
+		"""Initialize the MongoDB connection."""
+		self.client: Optional[AsyncIOMotorClient] = None
+		self.database = None
+
+	async def connect(self) -> None:
+		"""Connect to MongoDB and initialize Beanie."""
+		self.client = AsyncIOMotorClient(settings.database.URL)
+		self.database = self.client[settings.database.DATABASE_NAME]
+
+		# Initialize Beanie with document models
+		# Note: Document models should be imported here when they exist
+		await init_beanie(
+			database=self.database,
+			document_models=[],  # Add your document models here
+		)
+
+	async def close(self) -> None:
+		"""Close the MongoDB connection."""
+		if self.client:
+			self.client.close()
+
+	async def get_database(self):
+		"""Get the database instance."""
+		return self.database
+
+
+# Global MongoDB instance
+mongodb = MongoDB()
+{% endif %}

--- a/templates/fastapi_template/{{ project_name }}/src/{{ project_slug }}/core/config/base.py.jinja
+++ b/templates/fastapi_template/{{ project_name }}/src/{{ project_slug }}/core/config/base.py.jinja
@@ -125,11 +125,16 @@ class CloudSettings(BaseSettings):
 
 
 class DatabaseSettings(BaseSettings):
+	{% if database_type == 'sqlalchemy' %}
 	URL: str = "sqlite+aiosqlite:///./{{ project_name|upper }}.db"
 	ECHO: Annotated[
 		bool,
 		AfterValidator(true_bool_validator),
 	] = False
+	{% elif database_type == 'mongodb' %}
+	URL: str = "mongodb://localhost:27017"
+	DATABASE_NAME: str = "{{ project_name|lower }}_db"
+	{% endif %}
 
 	model_config: ClassVar[SettingsConfigDict] = SettingsConfigDict(
 		extra="ignore",

--- a/templates/fastapi_template/{{ project_name }}/tests/conftest.py.jinja
+++ b/templates/fastapi_template/{{ project_name }}/tests/conftest.py.jinja
@@ -4,11 +4,16 @@ from typing import Generator
 
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from {{ project_slug }}.api.application import app
 {% if database %}
+{% if database_type == 'sqlalchemy' %}
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from {{ project_slug }}.connection import database
+{% elif database_type == 'mongodb' %}
+from {{ project_slug }}.connection import mongodb
+{% endif %}
 {% endif %}
 
 
@@ -28,6 +33,7 @@ def client() -> Generator[TestClient, None, None]:
 
 
 {% if database %}
+{% if database_type == 'sqlalchemy' %}
 @pytest.fixture(scope="function")
 async def db_session() -> AsyncGenerator[AsyncSession, None]:
 	"""Create a database session for testing."""
@@ -40,4 +46,14 @@ async def db_session() -> AsyncGenerator[AsyncSession, None]:
 		except Exception:
 			await session.rollback()
 			raise
+{% elif database_type == 'mongodb' %}
+@pytest.fixture(scope="function")
+async def mongodb_client():
+	"""Create a MongoDB client for testing."""
+	await mongodb.connect()
+	try:
+		yield mongodb
+	finally:
+		await mongodb.close()
+{% endif %}
 {% endif %}

--- a/templates/fastapi_template/{{ project_name }}/tests/test_health.py.jinja
+++ b/templates/fastapi_template/{{ project_name }}/tests/test_health.py.jinja
@@ -3,7 +3,9 @@
 import pytest
 from fastapi.testclient import TestClient
 {% if database %}
+{% if database_type == 'sqlalchemy' %}
 from sqlalchemy.ext.asyncio import AsyncSession
+{% endif %}
 {% endif %}
 
 
@@ -19,6 +21,7 @@ class TestHealth:
 		assert data["status"] == "success"
 
 	{% if database %}
+	{% if database_type == 'sqlalchemy' %}
 	@pytest.mark.asyncio
 	async def test_health_endpoint_with_database(
 		self, client: TestClient, db_session: AsyncSession
@@ -30,4 +33,17 @@ class TestHealth:
 		assert "status" in data
 		assert data["status"] == "success"
 		# Note: Database health check not implemented in basic health endpoint
+	{% elif database_type == 'mongodb' %}
+	@pytest.mark.asyncio
+	async def test_health_endpoint_with_mongodb(
+		self, client: TestClient, mongodb_client: None,
+	) -> None:
+		"""Test health check with MongoDB connectivity."""
+		response = client.get("/")
+		assert response.status_code == 200
+		data = response.json()
+		assert "status" in data
+		assert data["status"] == "success"
+		# Note: Database health check not implemented in basic health endpoint
+	{% endif %}
 	{% endif %}

--- a/templates/fastapi_template/{{ project_name }}/tests/unit/test_config.py.jinja
+++ b/templates/fastapi_template/{{ project_name }}/tests/unit/test_config.py.jinja
@@ -39,6 +39,7 @@ class TestSettings:
 		assert settings.server.PORT > 0
 
 	{% if database %}
+	{% if database_type == 'sqlalchemy' %}
 	def test_database_settings(self) -> None:
 		"""Test database settings have expected attributes."""
 		settings = get_settings()
@@ -47,4 +48,14 @@ class TestSettings:
 		assert isinstance(settings.database.URL, str)
 		assert isinstance(settings.database.ECHO, bool)
 		assert "sqlite" in settings.database.URL  # Should contain sqlite for basic setup
+	{% elif database_type == 'mongodb' %}
+	def test_database_settings(self) -> None:
+		"""Test MongoDB database settings have expected attributes."""
+		settings = get_settings()
+		assert hasattr(settings.database, 'URL')
+		assert hasattr(settings.database, 'DATABASE_NAME')
+		assert isinstance(settings.database.URL, str)
+		assert isinstance(settings.database.DATABASE_NAME, str)
+		assert "mongodb" in settings.database.URL  # Should contain mongodb for MongoDB setup
+	{% endif %}
 	{% endif %}

--- a/test_cli.sh
+++ b/test_cli.sh
@@ -22,6 +22,7 @@ test_config() {
     local docker="$9"
     local use_cloud="${10}"
     local use_database="${11}"
+    local database_type="${12:-sqlalchemy}"
 
     echo "Testing: $config_name"
 
@@ -38,13 +39,13 @@ test_config() {
     fi
 
     if [ "$use_cloud" = "true" ]; then
-        cmd="$cmd --use-cloud --cloud-type aws"
+        cmd="$cmd --use-cloud"
     else
         cmd="$cmd --no-cloud"
     fi
 
     if [ "$use_database" = "true" ]; then
-        cmd="$cmd --use-database"
+        cmd="$cmd --use-database --database-type $database_type"
     else
         cmd="$cmd --no-database"
     fi
@@ -94,13 +95,13 @@ test_config() {
 
 # Test configurations
 echo "Testing basic FastAPI configuration..."
-test_config "fastapi-basic" "test-fastapi-basic" "fastapi" "$TEST_DIR" "3.13" "test@example.com" "Test User" "Test project" "true" "true" "true"
+test_config "fastapi-basic" "test-fastapi-basic" "fastapi" "$TEST_DIR" "3.13" "test@example.com" "Test User" "Test project" "true" "true" "true" "sqlalchemy"
 
 echo "Testing FastAPI without Docker..."
-test_config "fastapi-no-docker" "test-fastapi-no-docker" "fastapi" "$TEST_DIR" "3.13" "test@example.com" "Test User" "Test project" "false" "true" "true"
+test_config "fastapi-no-docker" "test-fastapi-no-docker" "fastapi" "$TEST_DIR" "3.13" "test@example.com" "Test User" "Test project" "false" "true" "true" "sqlalchemy"
 
 echo "Testing FastAPI without cloud..."
-test_config "fastapi-no-cloud" "test-fastapi-no-cloud" "fastapi" "$TEST_DIR" "3.13" "test@example.com" "Test User" "Test project" "true" "false" "true"
+test_config "fastapi-no-cloud" "test-fastapi-no-cloud" "fastapi" "$TEST_DIR" "3.13" "test@example.com" "Test User" "Test project" "true" "false" "true" "sqlalchemy"
 
 echo "Testing FastAPI without database..."
 test_config "fastapi-no-db" "test-fastapi-no-db" "fastapi" "$TEST_DIR" "3.13" "test@example.com" "Test User" "Test project" "true" "true" "false"
@@ -112,6 +113,12 @@ echo "Testing Python 3.12..."
 test_config "fastapi-py312" "test-fastapi-py312" "fastapi" "$TEST_DIR" "3.12" "test@example.com" "Test User" "Test project" "true" "true" "true"
 
 echo "Testing different destination..."
-test_config "fastapi-custom-dest" "test-fastapi-dest" "fastapi" "/tmp" "3.13" "test@example.com" "Test User" "Test project" "true" "true" "true"
+test_config "fastapi-custom-dest" "test-fastapi-dest" "fastapi" "/tmp" "3.13" "test@example.com" "Test User" "Test project" "true" "true" "true" "sqlalchemy"
+
+echo "Testing FastAPI with MongoDB..."
+test_config "fastapi-mongodb" "test-fastapi-mongodb" "fastapi" "$TEST_DIR" "3.13" "test@example.com" "Test User" "Test project" "true" "true" "true" "mongodb"
+
+echo "Testing FastAPI with MongoDB and no cloud..."
+test_config "fastapi-mongodb-no-cloud" "test-fastapi-mongodb-no-cloud" "fastapi" "$TEST_DIR" "3.13" "test@example.com" "Test User" "Test project" "true" "false" "true" "mongodb"
 
 echo "🧪 Testing complete!"


### PR DESCRIPTION
## Overview

Fixed MongoDB test failures in generated FastAPI projects. The test files were hardcoded for SQLAlchemy but failed when MongoDB was selected as the database type. Made all test-related templates conditional based on `database_type` to support both SQLAlchemy and MongoDB configurations.

## Type of Change

- [x] Bug fix

## Scope / Affected Areas
- [x] Developer tooling

## Breaking Changes

- [x] No

## Public API Impact (Python SDK)

- New modules/classes/functions:
- Changed/removed APIs:
- Deprecations (timeline and migration path):

## Testing & Verification

- Commands run locally:
	- [x] task test (pytest)
	- [x] task lint (ruff/pyright/mypy)
	- [x] pre-commit run --all-files (optional)
- Added/updated tests: [ ] unit [ ] integration
- Key scenarios and edge cases:
  - Generated FastAPI projects with MongoDB database type now have working tests
  - SQLAlchemy projects continue to work as before
  - Both database types use appropriate connection patterns and fixtures


## Documentation
- Notes:
  - MongoDB support in scaffoldr now includes proper test configuration

## Environment / Config Changes

- New/changed env vars:
- Defaults and validation:
- Backwards compatible: [yes]

## Checklist

- [x] Code formatted and linted (ruff format/check)
- [x] Type checks pass (pyright, mypy)
- [x] No secrets/keys committed